### PR TITLE
Update axios

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "autoprefixer": "7.1.6",
-    "axios": "^0.18.0",
+    "axios": "^0.21.1",
     "babel-core": "6.26.0",
     "babel-eslint": "7.2.3",
     "babel-jest": "20.0.3",


### PR DESCRIPTION
Because of security vulnerability:
https://github.com/advisories/GHSA-4w2v-q235-vp99

We do not use a proxy, so we are not vulnerable to this
specific vulnerability.